### PR TITLE
Text component + styles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Global } from '@emotion/core'
+import { styles } from "./App.styles";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import EntryPortal from "./components/EntryPortal";
 import HCPSignup from "./components/HCPSignup";
@@ -12,7 +13,7 @@ import Login from "./components/Login";
 import Logout from "./components/Logout";
 import Profile from "./components/Profile";
 import NewDropSite from "./components/NewDropSite";
-import { styles } from "./App.styles";
+import StyleGuide from "./components/StyleGuide";
 
 class App extends React.Component {
   constructor(props) {
@@ -68,6 +69,10 @@ class App extends React.Component {
 
             <Route exact path="/">
               <EntryPortal backend={this.props.backend} />
+            </Route>
+
+            <Route exact path="/style-guide">
+              <StyleGuide backend={this.props.backend} />
             </Route>
 
             <Route path="*">

--- a/src/components/StyleGuide.js
+++ b/src/components/StyleGuide.js
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import React from 'react'
+import { jsx } from '@emotion/core'
+import Text from './Text/Text'
+import { TEXT_TYPE } from './Text/Text.styles'
+
+class StyleGuide extends React.Component {
+  render() {
+    return (
+      <div css={{ maxWidth: '1200px', width: '100%', margin: '0 auto', padding: '1em'}}>
+        <h1>Style Guide</h1>
+        <hr />
+        <Text as='h1' type={TEXT_TYPE.HEADER_1}>Header 1</Text>
+        <Text as='h2' type={TEXT_TYPE.HEADER_2}>Header 2</Text>
+        <Text as='h3' type={TEXT_TYPE.HEADER_3}>Header 3</Text>
+        <Text as='h4' type={TEXT_TYPE.HEADER_4}>Header 4</Text>
+        <Text as='p' type={TEXT_TYPE.BODY_1}>Body 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean at nunc faucibus neque finibus ultrices a non risus.</Text>
+        <Text as='p' type={TEXT_TYPE.BODY_2}>Body 2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean at nunc faucibus neque finibus ultrices a non risus.</Text>
+        <Text as='p' type={TEXT_TYPE.NOTE}>Body 2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean at nunc faucibus neque finibus ultrices a non risus.</Text>
+        <hr />
+      </div>
+    );
+  }
+}
+
+export default StyleGuide;

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -1,0 +1,11 @@
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core'
+import { TEXT_TYPE, textStyles } from "./Text.styles"
+
+function Text({ children, type = TEXT_TYPE.BODY_1, as: Tag = 'span' }) {
+    return (
+        <Tag css={css(textStyles[type])}>{children}</Tag>
+    );
+  }
+
+export default Text;

--- a/src/components/Text/Text.styles.js
+++ b/src/components/Text/Text.styles.js
@@ -1,0 +1,58 @@
+export const Font = `"Inter", Helvetica, Arial, sans-serif`
+
+export const TEXT_TYPE = {
+  'HEADER_1': 'HEADER_1',
+  'HEADER_2': 'HEADER_2',
+  'HEADER_3': 'HEADER_3',
+  'HEADER_4': 'HEADER_4',
+  'BODY_1': 'BODY_1',
+  'BODY_2': 'BODY_2',
+  'NOTE': 'NOTE',
+}
+
+export const textStyles = {
+  [TEXT_TYPE.HEADER_1]: `
+    font-family: ${Font};
+    font-size: 40px;
+    line-height: 38px;
+    letter-spacing: -0.04em;
+  `,
+  [TEXT_TYPE.HEADER_2]: `
+    font-family: ${Font};
+    font-size: 30px;
+    font-weight: 600;
+    line-height: 34px;
+  `,
+  [TEXT_TYPE.HEADER_3]: `
+    font-family: ${Font};
+    font-size: 26px;
+    font-weight: 600;
+    line-height: 32px;
+    letter-spacing: -0.04em;
+  `,
+  [TEXT_TYPE.HEADER_4]: `
+    font-family: ${Font};
+    font-size: 24px;
+    font-weight: 500;
+    line-height: 26px;
+    letter-spacing: -0.03em;
+  `,
+  [TEXT_TYPE.BODY_1]: `
+    font-family: ${Font};
+    font-size: 16px;
+    line-height: 24px;
+    letter-spacing: -0.03em;
+  `,
+  [TEXT_TYPE.BODY_2]: `
+    font-family: ${Font};
+    font-size: 14px;
+    line-height: 22px;
+    letter-spacing: -0.01em;
+  `,
+  [TEXT_TYPE.NOTE]: `
+  font-family: ${Font};
+  font-size: 12px;
+  line-height: 18px;
+  letter-spacing: -0.01em;
+`,
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,7 @@
+@import url('https://fonts.googleapis.com/css?family=Inter&display=swap');
+
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: "Inter", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
 }


### PR DESCRIPTION
<img width="916" alt="Screen Shot 2020-03-23 at 8 49 32 PM" src="https://user-images.githubusercontent.com/11987517/77386334-d14fe080-6d47-11ea-90a8-0db16c163f7a.png">

- creates a text component
- `type` prop allows you to choose a text style - `HEADER_1` - `HEADER_4`, `BODY_1` + `BODY_2`, and `NOTE`
- `as` prop defines the text element used - `p`, `h1`, `h2`, `h3`, `h4`
- sets up a simple style guide page as a reference of all of our styled components
- imports inter google font and changes font globally
- removes unused code style